### PR TITLE
Throne/Conclave: Add permafrost

### DIFF
--- a/Throne/Conclave.lua
+++ b/Throne/Conclave.lua
@@ -42,6 +42,7 @@ function mod:GetOptions()
 		93059, -- Storm Shield
 		-- Nezir
 		84645, -- Wind Chill
+		86082, -- Permafrost
 		-- Anshal
 		85422, -- Nurture
 		86281, -- Toxic Spores
@@ -66,6 +67,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "StormShield", 93059)
 	self:Log("SPELL_CAST_SUCCESS", "WindBlast", 86193)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "WindChill", 84645)
+	self:Log("SPELL_CAST_SUCCESS", "Permafrost", 86082)
 	self:Log("SPELL_CAST_SUCCESS", "Nurture", 85422)
 	self:Log("SPELL_AURA_APPLIED", "ToxicSpores", 86281)
 	self:Log("SPELL_CAST_START", "SoothingBreeze", 86205)
@@ -77,6 +79,7 @@ function mod:OnEngage()
 	self:SimpleTimer(InitialBossCheck, 1)
 	self:Berserk(480)
 	self:Bar("full_power", 90, L["full_power"], 86193)
+	self:CDBar(86082, 11) -- Permafrost
 end
 
 --------------------------------------------------------------------------------
@@ -161,6 +164,11 @@ function mod:SoothingBreeze(args)
 	if unit and mod:UnitWithinRange(unit, 100) then
 		self:Message(args.spellId, "orange")
 	end
+end
+
+function mod:Permafrost(args)
+	self:CDBar(args.spellId, 11)
+	self:Message(args.spellId, "orange")
 end
 
 function mod:Nurture(args)

--- a/Throne/Conclave.lua
+++ b/Throne/Conclave.lua
@@ -79,7 +79,6 @@ function mod:OnEngage()
 	self:SimpleTimer(InitialBossCheck, 1)
 	self:Berserk(480)
 	self:Bar("full_power", 90, L["full_power"], 86193)
-	self:CDBar(86082, 11) -- Permafrost
 end
 
 --------------------------------------------------------------------------------
@@ -103,6 +102,7 @@ function InitialBossCheck()
 
 	local unit = mod:GetUnitIdByGUID(45871) -- Nezir
 	if unit and mod:UnitWithinRange(unit, 100) then
+		mod:CDBar(86082, 11) -- Permafrost
 		return
 	end
 
@@ -110,6 +110,7 @@ function InitialBossCheck()
 	mod:Bar(85422, 29) -- Nurture
 	mod:Bar(93059, 29) -- Storm Shield
 	mod:Bar(86193, 29) -- Wind Blast
+	mod:CDBar(86082, 11) -- Permafrost
 end
 
 function mod:FullPower(args)
@@ -168,7 +169,10 @@ end
 
 function mod:Permafrost(args)
 	self:CDBar(args.spellId, 11)
-	self:Message(args.spellId, "orange")
+	local unit = mod:GetUnitIdByGUID(args.sourceGUID)
+	if unit and mod:UnitWithinRange(unit, 100) then
+		self:Message(args.spellId, "orange")
+	end
 end
 
 function mod:Nurture(args)

--- a/Throne/Options/Colors.lua
+++ b/Throne/Options/Colors.lua
@@ -2,6 +2,7 @@
 BigWigs:AddColors("Conclave of Wind", {
 	[84645] = "blue",
 	[85422] = "orange",
+	[86082] = "orange",
 	[86193] = "red",
 	[86205] = "orange",
 	[86281] = "orange",


### PR DESCRIPTION
Added a timer for Nezir's Permafrost frontal attack

The ability works on with cooldown mechanic, 11s between casts minimum and it's the same for all 4 difficulties. It instantly casts after a full power ability, meaning the timer is not reset when the full power ability finishes


Cast logs for each difficult:
**25 heroic** ([link](https://classic.warcraftlogs.com/reports/zbTQDjLFvBq2f4CG#fight=4&type=casts&hostility=1&ability=86082&view=events)):
![image](https://github.com/user-attachments/assets/382a58b4-de69-49d1-b2d4-9ff045b984b9)
**25 normal** ([link](https://classic.warcraftlogs.com/reports/qbvRtQgZr48GYJFL#fight=32&type=casts&hostility=1&ability=86082&view=events)):
![image](https://github.com/user-attachments/assets/efcdf5bb-5439-4a6b-b952-bec6f2e36277)
**10 heroic** ([link](https://classic.warcraftlogs.com/reports/CYBp93AhK76kLrdT#fight=21&type=casts&hostility=1&ability=86082&view=events)):
![image](https://github.com/user-attachments/assets/001982d6-0bbe-4e42-949b-2aecbb62d42f)
**10 normal** ([link](https://classic.warcraftlogs.com/reports/NXw2AC6mHDGVrRk3#fight=49&type=casts&hostility=1&ability=86082&view=events)):
![image](https://github.com/user-attachments/assets/16e6b274-ed5c-4dfe-82d7-aa9b66037140)




 