### PR TITLE
Bastion/DoubleDragon: do not remove blackout timer on debuff removal

### DIFF
--- a/Bastion/DoubleDragon.lua
+++ b/Bastion/DoubleDragon.lua
@@ -184,7 +184,6 @@ function mod:BlackoutApplied(args)
 end
 
 function mod:BlackoutRemoved(args)
-	self:StopBar(args.spellName)
 	if self:Me(args.destGUID) then
 		self:CancelYellCountdown(args.spellId)
 	end


### PR DESCRIPTION
For the Theralion & Valiona boss fight in Cataclysm's Bastion of Twilight raid:

- When the Blackout debuff is applied to a unit, the Blackout timer is correctly reset to 45 seconds.
- When the same Blackout debuff is removed, the timer **incorrectly** is also removed - now we don't have a timer for the next Blackout.
- Blackout timer should only be removed when entering the "Theralion on ground" phase.

[Video demonstrating the issue](https://www.youtube.com/watch?v=s3gjPep-Ovs)
The BigWigs timers are in **grey & white** on the left side of the screen. The **blue** timers are from a different addon.