### PR TITLE
Firelands: Add encounter ID's and respawn timers

### DIFF
--- a/Firelands/Alysrazor.lua
+++ b/Firelands/Alysrazor.lua
@@ -5,6 +5,8 @@
 local mod, CL = BigWigs:NewBoss("Alysrazor", 720, 194)
 if not mod then return end
 mod:RegisterEnableMob(52530, 53898, 54015, 53089) --Alysrazor, Voracious Hatchling, Majordomo Staghelm, Molten Feather
+mod:SetEncounterID(1206)
+mod:SetRespawnTime(30)
 
 local woundTargets = mod:NewTargetList()
 local meteorCount, moltCount, burnCount, initiateCount = 0, 0, 0, 0
@@ -98,7 +100,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "Firestorm", 100744)
 	self:Log("SPELL_AURA_REMOVED", "FirestormOver", 100744)
 
-	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT", "CheckBossStatus")
 	self:RegisterEvent("CHAT_MSG_MONSTER_YELL", "Initiates")
 
 	self:Death("Win", 52530)

--- a/Firelands/Baleroc.lua
+++ b/Firelands/Baleroc.lua
@@ -5,6 +5,8 @@
 local mod = BigWigs:NewBoss("Baleroc", 720, 196)
 if not mod then return end
 mod:RegisterEnableMob(53494)
+mod:SetEncounterID(1200)
+mod:SetRespawnTime(30)
 
 local countdownTargets = mod:NewTargetList()
 local countdownCounter, shardCounter = 1, 0
@@ -47,7 +49,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "Shards", 99259)
 	self:Log("SPELL_CAST_START", "Blades", 99352, 99350)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "Torment", 99256)
-	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT", "CheckBossStatus")
 
 	self:Death("Win", 53494)
 end

--- a/Firelands/Bethtilac.lua
+++ b/Firelands/Bethtilac.lua
@@ -5,6 +5,8 @@
 local mod, CL = BigWigs:NewBoss("Beth'tilac", 720, 192)
 if not mod then return end
 mod:RegisterEnableMob(52498)
+mod:SetEncounterID(1197)
+mod:SetRespawnTime(30)
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -62,8 +64,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "Kiss", 99506)
 	self:Log("SPELL_CAST_START", "Devastate", 99052)
 	self:Log("SPELL_CAST_SUCCESS", "Flare", 99859)
-
-	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT", "CheckBossStatus")
 
 	self:Death("Win", 52498)
 end

--- a/Firelands/Ragnaros.lua
+++ b/Firelands/Ragnaros.lua
@@ -5,6 +5,8 @@
 local mod, CL = BigWigs:NewBoss("Ragnaros", 720, 198)
 if not mod then return end
 mod:RegisterEnableMob(52409, 53231) --Ragnaros, Lava Scion
+mod:SetEncounterID(1203)
+mod:SetRespawnTime(30)
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -89,8 +91,6 @@ function mod:OnBossEnable()
 
 	self:Log("SPELL_AURA_APPLIED", "BurningWound", 99399)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "BurningWound", 99399)
-
-	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT", "CheckBossStatus")
 
 	self:Death("Win", 52409)
 	self:Death("SonDeaths", 53140) -- Son of Flame

--- a/Firelands/Rhyolith.lua
+++ b/Firelands/Rhyolith.lua
@@ -5,6 +5,8 @@
 local mod, CL = BigWigs:NewBoss("Lord Rhyolith", 720, 193)
 if not mod then return end
 mod:RegisterEnableMob(52577, 53087, 52558) -- Left foot, Right Foot, Lord Rhyolith
+mod:SetEncounterID(1204)
+mod:SetRespawnTime(30)
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -58,8 +60,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_SUMMON", "Fragments", 98136)
 	self:Log("SPELL_AURA_REMOVED_DOSE", "ObsidianStack", 98632)
 	self:Log("SPELL_AURA_REMOVED", "Obsidian", 98632)
-
-	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT", "CheckBossStatus")
 
 	self:Death("Win", 52558)
 end

--- a/Firelands/Shannox.lua
+++ b/Firelands/Shannox.lua
@@ -5,6 +5,8 @@
 local mod, CL = BigWigs:NewBoss("Shannox", 720, 195)
 if not mod then return end
 mod:RegisterEnableMob(53691, 53695, 53694) --Shannox, Rageface, Riplimb
+mod:SetEncounterID(1205)
+mod:SetRespawnTime(30)
 
 --------------------------------------------------------------------------------
 -- Localization
@@ -50,8 +52,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "FaceRageRemoved", 99945, 99947)
 	self:Log("SPELL_CAST_SUCCESS", "HurlSpear", 99978)
 	self:Log("SPELL_SUMMON", "Traps", 99836, 99839) -- Throw Crystal Prison Trap, Throw Immolation Trap
-
-	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT", "CheckBossStatus")
 
 	self:Death("Win", 53691)
 end

--- a/Firelands/Staghelm.lua
+++ b/Firelands/Staghelm.lua
@@ -5,6 +5,8 @@
 local mod, CL = BigWigs:NewBoss("Majordomo Staghelm", 720, 197)
 if not mod then return end
 mod:RegisterEnableMob(52571, 53619) --Staghelm, Druid of the Flame
+mod:SetEncounterID(1185)
+mod:SetRespawnTime(30)
 
 --------------------------------------------------------------------------------
 -- Locales
@@ -64,8 +66,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "SearingSeedsApplied", 98450)
 	self:Log("SPELL_AURA_REMOVED", "SearingSeedsRemoved", 98450)
 	self:Log("SPELL_CAST_START", "BurningOrbs", 98451)
-
-	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT", "CheckBossStatus")
 
 	self:Death("Win", 52571)
 end


### PR DESCRIPTION
I suppose the `self:Death("Win", bossId)` callbacks can be removed now that we've got encounter ID's? Wasn't 100% sure so I left them in.