### PR TITLE
Firelands: Add some mods

### DIFF
--- a/Firelands/Alysrazor.lua
+++ b/Firelands/Alysrazor.lua
@@ -101,8 +101,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "FirestormOver", 100744)
 
 	self:RegisterEvent("CHAT_MSG_MONSTER_YELL", "Initiates")
-
-	self:Death("Win", 52530)
 end
 
 function mod:OnEngage()

--- a/Firelands/Baleroc.lua
+++ b/Firelands/Baleroc.lua
@@ -49,8 +49,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "Shards", 99259)
 	self:Log("SPELL_CAST_START", "Blades", 99352, 99350)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "Torment", 99256)
-
-	self:Death("Win", 53494)
 end
 
 function mod:OnEngage()

--- a/Firelands/Bethtilac.lua
+++ b/Firelands/Bethtilac.lua
@@ -64,8 +64,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "Kiss", 99506)
 	self:Log("SPELL_CAST_START", "Devastate", 99052)
 	self:Log("SPELL_CAST_SUCCESS", "Flare", 99859)
-
-	self:Death("Win", 52498)
 end
 
 function mod:OnEngage()

--- a/Firelands/Locales/deDE.lua
+++ b/Firelands/Locales/deDE.lua
@@ -73,6 +73,7 @@ if L then
 	L.immolationyou_message = "Brandfalle"
 	L.crystal = "Kristallgefängnisfalle"
 	L.crystal_desc = "Warnt, unter wen Shannox die Kristallgefängnisfalle ablegt."
+	L.facerage_trigger = "An die Gurgel!"
 end
 
 L = BigWigs:NewBossLocale("Baleroc", "deDE")

--- a/Firelands/Locales/frFR.lua
+++ b/Firelands/Locales/frFR.lua
@@ -73,6 +73,7 @@ if L then
 	L.immolationyou_message = "Piège d'immolation"
 	L.crystal = "Piège de cristal"
 	L.crystal_desc = "Prévient en dessous de qui Shannox incante un piège de cristal."
+	L.facerage_trigger = "À la gorge !"
 end
 
 L = BigWigs:NewBossLocale("Baleroc", "frFR")

--- a/Firelands/Locales/ruRU.lua
+++ b/Firelands/Locales/ruRU.lua
@@ -73,6 +73,7 @@ if L then
 	L.immolationyou_message = "Обжигающая ловушка"
 	L.crystal = "Кристаллическая ловушка"
 	L.crystal_desc = "Объявлять, когда Шэннокс бросает кристаллическую ловушку."
+	L.facerage_trigger = "Хватай за горло!"
 end
 
 L = BigWigs:NewBossLocale("Baleroc", "ruRU")

--- a/Firelands/Ragnaros.lua
+++ b/Firelands/Ragnaros.lua
@@ -92,7 +92,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "BurningWound", 99399)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "BurningWound", 99399)
 
-	self:Death("Win", 52409)
 	self:Death("SonDeaths", 53140) -- Son of Flame
 end
 

--- a/Firelands/Rhyolith.lua
+++ b/Firelands/Rhyolith.lua
@@ -46,7 +46,7 @@ L = mod:GetLocale()
 function mod:GetOptions()
 	return {
 		98552, 98136,
-		"armor", 97282, 98255, -2537, 101304, 98493
+		"armor", 97282, 98255, -2537, 101304, 98493, 97225
 	}, {
 		[98552] = L["adds_header"],
 		["armor"] = "general"
@@ -61,6 +61,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED_DOSE", "ObsidianStack", 98632)
 	self:Log("SPELL_AURA_REMOVED", "Obsidian", 98632)
 	self:Log("SPELL_CAST_SUCCESS", "HeatedVolcano", 98493)
+	self:Log("SPELL_CAST_SUCCESS", "MagmaFlow", 97225)
 end
 
 function mod:OnEngage()
@@ -78,6 +79,10 @@ end
 function mod:HeatedVolcano(args)
 	self:MessageOld(args.spellId, "yellow", "info")
 	self:CDBar(98493, self:Heroic() and 25.5 or 40)
+end
+
+function mod:MagmaFlow(args)
+	mod:MessageOld(args.spellId, "red", "alarm")
 end
 
 function mod:Obsidian(args)

--- a/Firelands/Rhyolith.lua
+++ b/Firelands/Rhyolith.lua
@@ -46,7 +46,7 @@ L = mod:GetLocale()
 function mod:GetOptions()
 	return {
 		98552, 98136,
-		"armor", 97282, 98255, -2537, 101304
+		"armor", 97282, 98255, -2537, 101304, 98493
 	}, {
 		[98552] = L["adds_header"],
 		["armor"] = "general"
@@ -60,11 +60,13 @@ function mod:OnBossEnable()
 	self:Log("SPELL_SUMMON", "Fragments", 98136)
 	self:Log("SPELL_AURA_REMOVED_DOSE", "ObsidianStack", 98632)
 	self:Log("SPELL_AURA_REMOVED", "Obsidian", 98632)
+	self:Log("SPELL_CAST_SUCCESS", "HeatedVolcano", 98493)
 end
 
 function mod:OnEngage()
 	self:Berserk(self:Heroic() and 300 or 360, nil, nil, 101304)
 	self:Bar(97282, 15, L["stomp"])
+	self:CDBar(98493, 30)
 	self:RegisterUnitEvent("UNIT_HEALTH", nil, "boss1")
 	lastFragments = GetTime()
 end
@@ -72,6 +74,11 @@ end
 --------------------------------------------------------------------------------
 -- Event Handlers
 --
+
+function mod:HeatedVolcano(args)
+	self:MessageOld(args.spellId, "yellow", "info")
+	self:CDBar(98493, self:Heroic() and 25.5 or 40)
+end
 
 function mod:Obsidian(args)
 	if self:MobId(args.destGUID) == 52558 then

--- a/Firelands/Rhyolith.lua
+++ b/Firelands/Rhyolith.lua
@@ -67,7 +67,7 @@ end
 function mod:OnEngage()
 	self:Berserk(self:Heroic() and 300 or 360, nil, nil, 101304)
 	self:Bar(97282, 15, L["stomp"])
-	self:CDBar(98493, 30)
+	self:CDBar(98493, 30) -- Heated Volcano
 	self:RegisterUnitEvent("UNIT_HEALTH", nil, "boss1")
 	lastFragments = GetTime()
 end
@@ -125,6 +125,7 @@ function mod:UNIT_HEALTH(event, unit)
 	if hp < 30 then -- phase starts at 25
 		self:MessageOld(-2537, "green", "info", L["phase2_warning"], 99846)
 		self:UnregisterUnitEvent(event, unit)
+		self:StopBar(98493) -- Heated Volcano
 		local _, stack = self:UnitBuff(unit, 98255) -- Molten Armor
 		if stack then
 			self:MessageOld(98255, "red", "alarm", L["molten_message"]:format(stack))

--- a/Firelands/Rhyolith.lua
+++ b/Firelands/Rhyolith.lua
@@ -60,8 +60,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_SUMMON", "Fragments", 98136)
 	self:Log("SPELL_AURA_REMOVED_DOSE", "ObsidianStack", 98632)
 	self:Log("SPELL_AURA_REMOVED", "Obsidian", 98632)
-
-	self:Death("Win", 52558)
 end
 
 function mod:OnEngage()

--- a/Firelands/Shannox.lua
+++ b/Firelands/Shannox.lua
@@ -29,6 +29,7 @@ if L then
 	L.crystal = "Crystal Trap"
 	L.crystal_desc = "Warn whom Shannox casts a Crystal Trap under."
 	L.crystal_icon = 99836
+	L.facerage_trigger = "Go for the throat!"
 end
 L = mod:GetLocale()
 
@@ -56,6 +57,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "FaceRageRemoved", 99945, 99947)
 	self:Log("SPELL_CAST_SUCCESS", "HurlSpear", 99978, 100002) -- Retail?, Cataclysm Classic
 	self:Log("SPELL_SUMMON", "Traps", 99836, 99839) -- Throw Crystal Prison Trap, Throw Immolation Trap
+	self:BossYell("FaceRageTrigger", L["facerage_trigger"])
 end
 
 function mod:OnEngage()
@@ -124,7 +126,6 @@ end
 function mod:FaceRage(args)
 	self:TargetMessageOld(100129, args.destName, "red", "alert")
 	self:PrimaryIcon(100129, args.destName)
-	self:CDBar(100129, 30) -- Face Rage
 end
 
 function mod:FaceRageRemoved(args)
@@ -132,3 +133,6 @@ function mod:FaceRageRemoved(args)
 	self:PrimaryIcon(100129)
 end
 
+function mod:FaceRageTrigger()
+	self:CDBar(100129, 30)
+end

--- a/Firelands/Shannox.lua
+++ b/Firelands/Shannox.lua
@@ -56,8 +56,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "FaceRageRemoved", 99945, 99947)
 	self:Log("SPELL_CAST_SUCCESS", "HurlSpear", 99978, 100002) -- Retail?, Cataclysm Classic
 	self:Log("SPELL_SUMMON", "Traps", 99836, 99839) -- Throw Crystal Prison Trap, Throw Immolation Trap
-
-	self:Death("Win", 53691)
 end
 
 function mod:OnEngage()

--- a/Firelands/Shannox.lua
+++ b/Firelands/Shannox.lua
@@ -60,6 +60,7 @@ end
 
 function mod:OnEngage()
 	self:Bar(100002, 23) -- Hurl Spear
+	self:CDBar(100129, 15) -- Face Rage
 	self:Berserk(600)
 end
 
@@ -123,6 +124,7 @@ end
 function mod:FaceRage(args)
 	self:TargetMessageOld(100129, args.destName, "red", "alert")
 	self:PrimaryIcon(100129, args.destName)
+	self:CDBar(100129, 30) -- Face Rage
 end
 
 function mod:FaceRageRemoved(args)

--- a/Firelands/Staghelm.lua
+++ b/Firelands/Staghelm.lua
@@ -66,8 +66,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "SearingSeedsApplied", 98450)
 	self:Log("SPELL_AURA_REMOVED", "SearingSeedsRemoved", 98450)
 	self:Log("SPELL_CAST_START", "BurningOrbs", 98451)
-
-	self:Death("Win", 52571)
 end
 
 function mod:OnEngage()


### PR DESCRIPTION
### Shannox: Face Rage Cooldown Timer
Using `BossYell` instead of `SPELL_CAST_SUCCESS` for this as it is more reliable/accurate. Copied boss quotes from wowhead for the localized strings.

`SPELL_CAST_SUCCESS` was unreliable in that Rageface would occasionally leap to his target but get encased in a prison trap before having the chance to cast Face Rage (no `SPELL_CAST_SUCCESS` event being fired). Despite this, a 30 second cooldown is still triggered. Relying on the boss yell has been a reliable alternative.

### Rhyolith: Heated Volcano Cooldown Timer
Quite nice to have for the 'driver' so he knows when to look for a new active volcano

### Rhyolith: Magma Flows Warning Message
This is the lines of lava that emanate out from the crushed volcanoes / magma pools. Found myself frequently getting hit by the lines when they are first being formed. This has helped a lot with catching them in time to avoid.