### PR TITLE
Frielands/Ragnaros: Improve Magma Trap bars

### DIFF
--- a/Firelands/Ragnaros.lua
+++ b/Firelands/Ragnaros.lua
@@ -252,6 +252,7 @@ function mod:SplittingBlow(args)
 	self:StopBar(lavaWaves)
 	self:StopBar(98263) -- Wrath of Ragnaros
 	self:StopBar(98498) -- Molten Seed
+	self:StopBar(98164) -- Magma Trap
 end
 
 function mod:SulfurasSmash(args)

--- a/Firelands/Ragnaros.lua
+++ b/Firelands/Ragnaros.lua
@@ -98,6 +98,7 @@ end
 function mod:OnEngage()
 	self:Bar(98237, 25, L["hand_bar"])
 	self:Bar(98710, 30, lavaWaves)
+	self:CDBar(98164, 15) -- Magma Trap
 	self:OpenProximity("proximity", 6)
 	self:Berserk(1080)
 	lavaWavesCD, dreadflameCD = 30, 40


### PR DESCRIPTION
- Stop Magma Trap bar on intermission (it's a CDBar so doesn't stop by itself)
- Add 15 second Magma Trap CDBar on encounter start