### PR TITLE
Firelands/Alysrazor: Fix Firestorm bar

### DIFF
--- a/Firelands/Alysrazor.lua
+++ b/Firelands/Alysrazor.lua
@@ -98,9 +98,9 @@ function mod:OnBossEnable()
 	-- Heroic only
 	self:Log("SPELL_CAST_START", "Meteor", 100761, 102111)
 	self:Log("SPELL_CAST_START", "Firestorm", 100744)
-	self:Log("SPELL_AURA_REMOVED", "FirestormOver", 100744)
 
 	self:RegisterEvent("CHAT_MSG_MONSTER_YELL", "Initiates")
+	self:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_STOP", "FirestormOver", "boss1")
 end
 
 function mod:OnEngage()
@@ -109,7 +109,7 @@ function mod:OnEngage()
 		initiateTimes = {22, 63, 21, 21, 40}
 		self:MessageOld(99816, "yellow", nil, L["engage_message"]:format(4), "inv_misc_pheonixpet_01")
 		self:Bar(99816, 250, L["stage_message"]:format(2))
-		self:Bar(100744, 95) -- Firestorm
+		self:CDBar(100744, 95) -- Firestorm
 		self:CDBar("meteor", 30, L["meteor"], 100761)
 		self:Bar("eggs", 42, 58542, L["eggs_icon"]) -- Hatch Eggs
 		self:DelayedMessage("eggs", 41.5, "green", 58542, L["eggs_icon"]) -- Hatch Eggs
@@ -213,13 +213,16 @@ end
 function mod:Firestorm(args)
 	self:Flash(args.spellId)
 	self:MessageOld(args.spellId, "orange", "alert")
+	self:StopBar(args.spellId)
 	self:Bar(args.spellId, 10, CL["cast"]:format(args.spellName))
 end
 
-function mod:FirestormOver(args)
+function mod:FirestormOver(_, _, _, spellId)
+	if spellId ~= 100744 then return end
+
 	-- Only show a bar for next if we have seen less than 3 meteors
 	if meteorCount < 3 then
-		self:CDBar(args.spellId, 72)
+		self:CDBar(100744, 72) -- Firestorm
 	end
 	self:Bar("meteor", meteorCount == 2 and 11.5 or 21.5,  L["meteor"], 100761)
 	self:Bar("eggs", 22.5, 58542, L["eggs_icon"]) -- Hatch Eggs
@@ -279,7 +282,7 @@ do
 			if self:Heroic() then
 				meteorCount = 0
 				self:Bar("meteor", 19, L["meteor"], 100761)
-				self:Bar(100744, 72) -- Firestorm
+				self:CDBar(100744, 72) -- Firestorm
 				self:Bar(99816, 225, L["stage_message"]:format(2)) -- Just adding 60s like OnEngage
 				self:Bar("eggs", 30, 58542, L["eggs_icon"]) -- Hatch Eggs
 				self:DelayedMessage("eggs", 29.5, "green", 58542, L["eggs_icon"]) -- Hatch Eggs


### PR DESCRIPTION
Currently, the `FirestormOver` method is supposed to be triggered by a `SPELL_AURA_REMOVED` combat log event:
`self:Log("SPELL_AURA_REMOVED", "FirestormOver", 100744)`

Turns out there are no aura-related events for Firestorm firing in the combat log for some reason.

Confirmed that the spell ID is correct for the aura.
![mpc-hc64_amrndgrPmq](https://github.com/user-attachments/assets/42636e8b-cd3e-40ab-b3e3-26b1a665b6f5)

For a solution, using `self:SimpleTimer(function() self:FirestormOver(args) end, 10)` in the `Firestorm` method instead of `self:Log("SPELL_AURA_REMOVED", "FirestormOver", 100744)`