### PR TITLE
Firelands/Ragnaros: Improve various timings

### DIFF
--- a/Firelands/Ragnaros.lua
+++ b/Firelands/Ragnaros.lua
@@ -97,7 +97,7 @@ end
 
 function mod:OnEngage()
 	self:Bar(98237, 25, L["hand_bar"])
-	self:Bar(98710, 30, lavaWaves)
+	self:CDBar(98710, 30, lavaWaves)
 	self:CDBar(98164, 15) -- Magma Trap
 	self:CDBar(98263, 5) -- Wrath of Ragnaros
 	self:OpenProximity("proximity", 6)
@@ -208,19 +208,20 @@ function mod:IntermissionEnd()
 		self:OpenProximity("proximity", 6)
 		if self:Heroic() then
 			self:CDBar(98498, 15) -- Molten Seed
-			self:Bar(98710, 7.5, lavaWaves)
+			self:CDBar(98710, 5, lavaWaves)
 			self:Bar(100171, 40) -- World in Flames
 		else
 			self:Bar(98498, 22.7) -- Molten Seed
-			self:Bar(98710, 55, lavaWaves)
+			self:CDBar(98710, 15, lavaWaves)
 		end
 	elseif phase == 2 then
+		lavaWavesCD = 30
 		engulfingCD = 30
 		if self:Heroic() then
 			self:Bar(100171, engulfingCD) -- World in Flames
 		end
 		self:CDBar(99317, 52) -- Living Meteor
-		self:Bar(98710, 55, lavaWaves)
+		self:CDBar(98710, 15, lavaWaves)
 		self:RegisterUnitEvent("UNIT_AURA", "FixatedCheck", "player")
 		self:UnregisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "boss1")
 	end
@@ -260,7 +261,7 @@ function mod:SulfurasSmash(args)
 		self:CDBar(98263, 12.5) -- Wrath of Ragnaros
 	end
 	self:MessageOld(args.spellId, "yellow", "info", lavaWaves)
-	self:Bar(args.spellId, lavaWavesCD, lavaWaves)
+	self:CDBar(args.spellId, lavaWavesCD, lavaWaves)
 end
 
 function mod:WorldInFlames(args)

--- a/Firelands/Ragnaros.lua
+++ b/Firelands/Ragnaros.lua
@@ -313,8 +313,8 @@ do
 			if t-prev > 5 then
 				prev = t
 				self:MessageOld(98498, "orange", "alarm")
-				self:Bar(98498, 12, L["seed_explosion"])
-				self:Bar(98498, 60)
+				self:Bar(98498, 11, L["seed_explosion"])
+				self:Bar(98498, 61.4)
 			end
 		elseif self:SpellName(spellId) == self:SpellName(98333) then
 			self:Error(("Found new id %d"):format(spellId)) -- XXX 98333 is the id on hc25, check normal

--- a/Firelands/Ragnaros.lua
+++ b/Firelands/Ragnaros.lua
@@ -99,6 +99,7 @@ function mod:OnEngage()
 	self:Bar(98237, 25, L["hand_bar"])
 	self:Bar(98710, 30, lavaWaves)
 	self:CDBar(98164, 15) -- Magma Trap
+	self:CDBar(98263, 5) -- Wrath of Ragnaros
 	self:OpenProximity("proximity", 6)
 	self:Berserk(1080)
 	lavaWavesCD, dreadflameCD = 30, 40
@@ -232,9 +233,7 @@ function mod:HandofRagnaros(args)
 end
 
 function mod:WrathofRagnaros(args)
-	if self:Difficulty() == 5 then
-		self:CDBar(args.spellId, 25)
-	end
+	self:CDBar(args.spellId, 25.5)
 end
 
 function mod:SplittingBlow(args)
@@ -257,8 +256,8 @@ function mod:SplittingBlow(args)
 end
 
 function mod:SulfurasSmash(args)
-	if phase == 1 and self:Difficulty() ~= 5 then
-		self:CDBar(98263, 12)
+	if phase == 1 and self:BarTimeLeft(98263) < 12.5 then
+		self:CDBar(98263, 12.5) -- Wrath of Ragnaros
 	end
 	self:MessageOld(args.spellId, "yellow", "info", lavaWaves)
 	self:Bar(args.spellId, lavaWavesCD, lavaWaves)

--- a/Firelands/Ragnaros.lua
+++ b/Firelands/Ragnaros.lua
@@ -119,21 +119,18 @@ end
 --
 
 function mod:Phase4()
-	--10% Yell is Phase 4 for heroic, and victory for normal
-	if self:Heroic() then
-		self:StopBar(livingMeteor)
-		self:StopBar(lavaWaves)
-		self:StopBar(98498) -- Molten Seed
-		phase = 4
-		 -- not sure if we want a different option key or different icon
-		self:MessageOld(98953, "green", nil, CL["phase"]:format(phase))
-		self:Bar(100479, 34) -- Breadth of Frost
-		self:Bar(100714, 51) -- Cloudburst
-		self:Bar(100646, 68) -- Entraping Roots
-		self:Bar(100604, 90) -- Empower Sulfuras
-	else
-		self:Win()
-	end
+	if not self:Heroic() then return end
+
+	self:StopBar(livingMeteor)
+	self:StopBar(lavaWaves)
+	self:StopBar(98498) -- Molten Seed
+	phase = 4
+	-- not sure if we want a different option key or different icon
+	self:MessageOld(98953, "green", nil, CL["phase"]:format(phase))
+	self:Bar(100479, 34) -- Breadth of Frost
+	self:Bar(100714, 51) -- Cloudburst
+	self:Bar(100646, 68) -- Entraping Roots
+	self:Bar(100604, 90) -- Empower Sulfuras
 end
 
 function mod:Dreadflame()


### PR DESCRIPTION
### Wrath of Ragnaros
- Added initial cast, always 5-6 seconds into the encounter
- Has a 25-26 second cooldown - remains the same for both normal & heroic
- Sulfuras Smash will put Wrath of Ragnaros on a 10 second cooldown unless it's already on cooldown for a longer duration

As the 1st one comes in at ~5 seconds & it's got a ~25 second cooldown, we would expect the 2nd one to come in at ~30 seconds ([1](https://classic.warcraftlogs.com/reports/4tfhzgQ3vk9yCKXn?fight=28&type=casts&view=events&hostility=1&pins=2%24Off%24%23244F4B%24expression%24ability.name+IN+%28%22Wrath+of+Ragnaros%22%2C+%22Sulfuras+Smash%22%29), [2](https://classic.warcraftlogs.com/reports/4xy2HQaPB8VjAMTh?fight=26&type=casts&hostility=1&view=events&pins=2%24Off%24%23244F4B%24expression%24ability.name+IN+%28%22Wrath+of+Ragnaros%22%2C+%22Sulfuras+Smash%22%29), [3](https://classic.warcraftlogs.com/reports/qcXPZfNvMpR6DWdg?fight=40&type=casts&view=events&hostility=1&pins=2%24Off%24%23244F4B%24expression%24ability.name+IN+%28%22Wrath+of+Ragnaros%22%2C+%22Sulfuras+Smash%22%29))

However, Ragnaros will typically begin casting Sulfuras Smash at ~30 seconds (2.5s cast time). This will cause Wrath of Ragnaros to be cast about 10 seconds later ([1](https://classic.warcraftlogs.com/reports/yCvNP1n7pYKG2D89?fight=22&type=casts&hostility=1&view=events&pins=2%24Off%24%23244F4B%24expression%24ability.name+IN+%28%22Wrath+of+Ragnaros%22%2C+%22Sulfuras+Smash%22%29), [2](https://classic.warcraftlogs.com/reports/bNq1m28ZrJDp4knH?fight=29&type=casts&hostility=1&pins=2%24Off%24%23244F4B%24expression%24ability.name+IN+%28%22Wrath+of+Ragnaros%22%2C+%22Sulfuras+Smash%22%29&view=events), [3](https://classic.warcraftlogs.com/reports/MHvWf1mrAJ4hkznX?fight=32&type=casts&view=events&hostility=1&pins=2%24Off%24%23244F4B%24expression%24ability.name+IN+%28%22Wrath+of+Ragnaros%22%2C+%22Sulfuras+Smash%22%29))

Using 12.5 seconds instead of 10 because we need account for Sulfuras Smash's cast time. (The Sulfuras Smash trigger is using `SPELL_CAST_START`, not `SPELL_CAST_SUCCESS`)

### Phase 4 Callback
- This was triggering a `Win` call on normal mode which is no longer needed since we've got the encounter ID's now

### Lava Waves & Molten Seed
- More accurate timings